### PR TITLE
added goal visualization to planner_manager

### DIFF
--- a/ros/src/fastrack/include/fastrack/planning/planner_manager.h
+++ b/ros/src/fastrack/include/fastrack/planning/planner_manager.h
@@ -98,7 +98,7 @@ protected:
   virtual void TimerCallback(const ros::TimerEvent& e);
 
   // Create and publish a marker at goal state. 
-  const virtual void VisualizeGoal();
+  virtual void VisualizeGoal() const ;
 
   // Callback for processing trajectory updates.
   inline void TrajectoryCallback(const fastrack_msgs::Trajectory::ConstPtr& msg) {
@@ -338,7 +338,7 @@ void PlannerManager<S>::TimerCallback(const ros::TimerEvent& e) {
 
 // Converts the goal state into a Rviz marker. 
 template<typename S>
-void PlannerManager<S>::VisualizeGoal() {
+void PlannerManager<S>::VisualizeGoal() const {
   // Set up sphere marker.
   visualization_msgs::Marker sphere;
   sphere.ns = "sphere";

--- a/ros/src/fastrack/include/fastrack/planning/planner_manager.h
+++ b/ros/src/fastrack/include/fastrack/planning/planner_manager.h
@@ -98,7 +98,7 @@ protected:
   virtual void TimerCallback(const ros::TimerEvent& e);
 
   // Create and publish a marker at goal state. 
-  virtual void VisualizeGoal();
+  const virtual void VisualizeGoal();
 
   // Callback for processing trajectory updates.
   inline void TrajectoryCallback(const fastrack_msgs::Trajectory::ConstPtr& msg) {
@@ -342,7 +342,7 @@ void PlannerManager<S>::VisualizeGoal() {
   // Set up sphere marker.
   visualization_msgs::Marker sphere;
   sphere.ns = "sphere";
-  sphere.header.frame_id = this->fixed_frame_;
+  sphere.header.frame_id = fixed_frame_;
   sphere.header.stamp = ros::Time::now();
   sphere.id = 0;
   sphere.type = visualization_msgs::Marker::SPHERE;
@@ -356,7 +356,6 @@ void PlannerManager<S>::VisualizeGoal() {
 
   // Fill in center and scale.
   sphere.scale.x = 0.1;
-  std::cout << "goal at: " << goal_ << std::endl;
   center.x = goal_.x[0];
 
   sphere.scale.y = 0.1;

--- a/ros/src/fastrack/include/fastrack/planning/planner_manager.h
+++ b/ros/src/fastrack/include/fastrack/planning/planner_manager.h
@@ -97,6 +97,9 @@ protected:
   // derived classes should still call thhis function.
   virtual void TimerCallback(const ros::TimerEvent& e);
 
+  // Create and publish a marker at goal state. 
+  virtual void VisualizeGoal();
+
   // Callback for processing trajectory updates.
   inline void TrajectoryCallback(const fastrack_msgs::Trajectory::ConstPtr& msg) {
     traj_ = Trajectory<S>(msg);
@@ -137,7 +140,7 @@ protected:
   double time_step_;
 
   // Publishers/subscribers and related topics.
-  ros::Publisher bound_pub_;
+  ros::Publisher goal_pub_;
   ros::Publisher ref_pub_;
   ros::Publisher replan_request_pub_;
   ros::Publisher traj_vis_pub_;
@@ -145,7 +148,7 @@ protected:
   ros::Subscriber ready_sub_;
   ros::Subscriber updated_env_sub_;
 
-  std::string bound_topic_;
+  std::string goal_topic_;
   std::string ref_topic_;
   std::string replan_request_topic_;
   std::string traj_vis_topic_;
@@ -203,7 +206,7 @@ bool PlannerManager<S>::LoadParameters(const ros::NodeHandle& n) {
   if (!nl.getParam("topic/replan_request", replan_request_topic_)) return false;
   if (!nl.getParam("topic/updated_env", updated_env_topic_)) return false;
   if (!nl.getParam("vis/traj", traj_vis_topic_)) return false;
-  if (!nl.getParam("vis/bound", bound_topic_)) return false;
+  if (!nl.getParam("vis/goal", goal_topic_)) return false;
 
   // Frames.
   if (!nl.getParam("frame/fixed", fixed_frame_)) return false;
@@ -241,8 +244,8 @@ bool PlannerManager<S>::RegisterCallbacks(const ros::NodeHandle& n) {
   replan_request_pub_ = nl.advertise<fastrack_msgs::ReplanRequest>(
     replan_request_topic_.c_str(), 1, false);
 
-  bound_pub_ = nl.advertise<visualization_msgs::Marker>(
-    bound_topic_.c_str(), 1, false);
+  goal_pub_ = nl.advertise<visualization_msgs::Marker>(
+    goal_topic_.c_str(), 1, false);
 
   traj_vis_pub_ = nl.advertise<visualization_msgs::Marker>(
     traj_vis_topic_.c_str(), 1, false);
@@ -260,6 +263,9 @@ bool PlannerManager<S>::RegisterCallbacks(const ros::NodeHandle& n) {
 // classes with more specific replanning needs.
 template<typename S>
 void PlannerManager<S>::MaybeRequestTrajectory() {
+  // Publish marker at goal location. 
+  VisualizeGoal();
+
   if (!ready_ || waiting_for_traj_) {
     return;
   }
@@ -328,6 +334,46 @@ void PlannerManager<S>::TimerCallback(const ros::TimerEvent& e) {
   tf.transform.rotation.w = 1;
 
   tf_broadcaster_.sendTransform(tf);
+}
+
+// Converts the goal state into a Rviz marker. 
+template<typename S>
+void PlannerManager<S>::VisualizeGoal() {
+  // Set up sphere marker.
+  visualization_msgs::Marker sphere;
+  sphere.ns = "sphere";
+  sphere.header.frame_id = this->fixed_frame_;
+  sphere.header.stamp = ros::Time::now();
+  sphere.id = 0;
+  sphere.type = visualization_msgs::Marker::SPHERE;
+  sphere.action = visualization_msgs::Marker::ADD;
+  sphere.color.a = 1.0;
+  sphere.color.r = 0.3;
+  sphere.color.g = 0.7;
+  sphere.color.b = 0.7;
+
+  geometry_msgs::Point center;
+
+  // Fill in center and scale.
+  sphere.scale.x = 0.1;
+  std::cout << "goal at: " << goal_ << std::endl;
+  center.x = goal_.x[0];
+
+  sphere.scale.y = 0.1;
+  center.y = goal_.x[1];
+
+  sphere.scale.z = 0.1;
+  center.z = goal_.x[2];
+
+  sphere.pose.position = center;
+  sphere.pose.orientation.x = 0.0;
+  sphere.pose.orientation.y = 0.0;
+  sphere.pose.orientation.z = 0.0;
+  sphere.pose.orientation.w = 1.0;
+
+  goal_pub_.publish(sphere);
+
+  return;
 }
 
 } //\namespace planning

--- a/ros/src/fastrack_crazyflie_demos/launch/position_velocity_planner_manager.launch
+++ b/ros/src/fastrack_crazyflie_demos/launch/position_velocity_planner_manager.launch
@@ -8,7 +8,7 @@
   <arg name="updated_env_topic" default="/updated_env" />
   <arg name="ref_topic" default="/ref" />
   <arg name="traj_vis" default="/vis/traj" />
-  <arg name="bound_vis" default="/vis/bound" />
+  <arg name="goal_vis" default="/vis/goal" />
 
   <!-- Frames of reference. -->
   <arg name="fixed_frame" default="world" />
@@ -33,7 +33,7 @@
     <param name="topic/replan_request" value="$(arg replan_request_topic)" />
     <param name="topic/updated_env" value="$(arg updated_env_topic)" />
     <param name="vis/traj" value="$(arg traj_vis)" />
-    <param name="vis/bound" value="$(arg bound_vis)" />
+    <param name="vis/goal" value="$(arg goal_vis)" />
 
     <param name="frame/fixed" value="$(arg fixed_frame)" />
     <param name="frame/planner" value="$(arg planner_frame)" />

--- a/ros/src/fastrack_crazyflie_demos/launch/software_demo.launch
+++ b/ros/src/fastrack_crazyflie_demos/launch/software_demo.launch
@@ -23,6 +23,7 @@
   <arg name="sensor_vis_topic" default="/vis/sensor" />
   <arg name="traj_vis_topic" default="/vis/traj" />
   <arg name="bound_vis_topic" default="/vis/bound" />
+  <arg name="goal_vis_topic" default="/vis/goal" />
   <arg name="known_env_vis_topic" default="/vis/known_env" />
   <arg name="true_env_vis_topic" default="/vis/true_env" />
 
@@ -156,7 +157,7 @@
     <arg name="replan_request_topic" value="$(arg replan_request_topic)" />
     <arg name="ref_topic" value="$(arg fastrack_reference_state_topic)" />
     <arg name="traj_vis" value="$(arg traj_vis_topic)" />
-    <arg name="bound_vis" value="$(arg bound_vis_topic)" />
+    <arg name="goal_vis" default="$(arg goal_vis_topic)" />
     <arg name="fixed_frame" value="$(arg fixed_frame)" />
     <arg name="planner_frame" value="$(arg planner_frame)" />
     <arg name="planner_runtime" value="$(arg planner_runtime)" />


### PR DESCRIPTION
Changed the unused bound_pub to be goal_pub and publish a marker at the goal state upon MaybeRequestTrajectory() call. Updated the position-velocity manager launch file to reflect the change of bound_pub to goal_pub (and corresponding topics). 